### PR TITLE
Steps 18-20

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,8 @@ We generated the command to join the Kubernetes cluster in the controller by del
 ### Run Join Command (Step 19)
 
 We run the command generated in Step 19 in order to join the worker to the Kubernetes cluster.
+Currently, this step gives the following error: `dial tcp 192.168.56.100:6443: connect: protocol not available.`
+The issue appear to be that worker node (`node-1`) cannot establish a TCP connection to the Kubernetes API server on the at `192.168.56.100:6443`.
 
 ### Install MetalLB (Step 20)
 

--- a/README.md
+++ b/README.md
@@ -376,7 +376,17 @@ We installed Helm, the Kubernetes package manager, by adding its official APT re
 
 Also, we installed the `helm-diff` plugin to improve visibility into Helm changes and make Ansible's provisioning more reliable by avoiding unnecessary re-installs during re-provisioning.
 
+### Generate Join Command (Step 18)
 
+We generated the command to join the Kubernetes cluster in the controller by delegating it using the `delegate_to` parameter. The command is stored in a variable.
+
+### Run Join Command (Step 19)
+
+We run the command generated in Step 19 in order to join the worker to the Kubernetes cluster.
+
+### Install MetalLB (Step 20)
+
+We installed MetalLB, adding an IPAdressPool and configuring an L2Advertisement.
 
 ## [⚙️ GitHub Actions & CI/CD](#️-github-actions--cicd)
 

--- a/provisioning/finalization.yml
+++ b/provisioning/finalization.yml
@@ -1,0 +1,29 @@
+- name: finalization
+  hosts: all
+  become: true
+
+  tasks:
+  # Step 20. Install MetalLB
+  - name: Install MetalLB CRDs
+    ansible.builtin.command: >
+      kubectl apply 
+      --kubeconfig /etc/kubernetes/admin.conf
+      -f https://raw.githubusercontent.com/metallb/metallb/v0.14.9/config/manifests/metallb-native.yaml  
+
+  - name: Wait for MetalLB provisioning to finish
+    ansible.builtin.command: >
+     kubectl wait 
+     --kubeconfig /etc/kubernetes/admin.conf
+      -n metallb-system -l app=metallb,component=controller --for=condition=ready pod --timeout=180s
+
+  - name: Add IPAddressPool
+    ansible.builtin.command: >
+      kubectl apply 
+      --kubeconfig /etc/kubernetes/admin.conf
+      -f ip-address-pool.yaml
+
+  - name: Add L2Advertisement
+    ansible.builtin.command: >
+      kubectl apply 
+      --kubeconfig /etc/kubernetes/admin.conf
+      -f l2-advertisement.yaml

--- a/provisioning/ip-address-pool.yaml
+++ b/provisioning/ip-address-pool.yaml
@@ -1,0 +1,8 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: address-pool
+  namespace: metallb-system
+spec:
+  addresses:
+  - 192.168.56.90-192.168.56.99

--- a/provisioning/l2-advertisement.yaml
+++ b/provisioning/l2-advertisement.yaml
@@ -1,0 +1,8 @@
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: default-l2ad
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - address-pool

--- a/provisioning/node.yml
+++ b/provisioning/node.yml
@@ -1,20 +1,28 @@
 - name: deploy
-  hosts: workers
+  hosts: node-1, node-2
   become: yes
 
   tasks:
+    - name: Ensure kubelet is started and enabled
+      ansible.builtin.systemd:
+        name: kubelet
+        state: started
+        enabled: yes
+
     # Step 18. Generate join command for setting up k8s workers
     - name: Generate join command
       ansible.builtin.command: >
         kubeadm token create
         --print-join-command
-      delegate_to: 192.168.56.100
+      delegate_to: ctrl
       register: join_command
+
+    - name: Print join command
+      debug:
+        var: join_command.stdout
 
     # Step 19. Run join command
     - name: Run join command
-      ansible.builtin.shell:
-        "{{ join_command.stdout }}"
-
-        
-
+      ansible.builtin.shell: "{{ join_command.stdout }} --ignore-preflight-errors=all"
+      args:
+        creates: /etc/kubernetes/kubelet.conf

--- a/provisioning/node.yml
+++ b/provisioning/node.yml
@@ -3,6 +3,18 @@
   become: yes
 
   tasks:
+    # Step 18. Generate join command for setting up k8s workers
+    - name: Generate join command
+      ansible.builtin.command: >
+        kubeadm token create
+        --print-join-command
+      delegate_to: 192.168.56.100
+      register: join_command
+
+    # Step 19. Run join command
+    - name: Run join command
+      ansible.builtin.shell:
+        "{{ join_command.stdout }}"
 
         
 


### PR DESCRIPTION
## Overview

### Generate Join Command (Step 18)

We generated the command to join the Kubernetes cluster in the controller by delegating it using the `delegate_to` parameter. The command is stored in a variable.

### Run Join Command (Step 19)

We run the command generated in Step 19 in order to join the worker to the Kubernetes cluster.
Currently, this step gives the following error: `dial tcp 192.168.56.100:6443: connect: protocol not available.`
The issue appear to be that worker node (`node-1`) cannot establish a TCP connection to the Kubernetes API server on the at `192.168.56.100:6443`.
Issue: #29 

### Install MetalLB (Step 20)

We installed MetalLB, adding an IPAdressPool and configuring an L2Advertisement.

## 📋 Pull Request Checklist

Please review and check all the following:

- [ ] I have added an overview of the changes
- [ ] I have tested my changes locally
- [ ] I have updated documentation (if applicable)

---

## 🚀 Versioning (Required for GitVersion)

- [ ] The **PR includes a commit** with one of the following GitVersion tags in the **message**:
  - `#major` – breaking change
  - `#minor` – new feature
  - `#patch` – bug fix or minor update  
  - _If omitted, the version will default to_ `patch`
