### PR TITLE
Fix step 18 and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,8 +383,6 @@ We generated the command to join the Kubernetes cluster in the controller by del
 ### Run Join Command (Step 19)
 
 We run the command generated in Step 19 in order to join the worker to the Kubernetes cluster.
-Currently, this step gives the following error: `dial tcp 192.168.56.100:6443: connect: protocol not available.`
-The issue appear to be that worker node (`node-1`) cannot establish a TCP connection to the Kubernetes API server on the at `192.168.56.100:6443`.
 
 ### Install MetalLB (Step 20)
 

--- a/provisioning/node.yml
+++ b/provisioning/node.yml
@@ -15,6 +15,7 @@
         kubeadm token create
         --print-join-command
       delegate_to: ctrl
+      run_once: true
       register: join_command
 
     - name: Print join command


### PR DESCRIPTION
## Overview
Without the line `run_once: true` in node.yml, the join command would try to be generated twice (one for node-1 and another time for node-2). This could lead to an error but is now fixed.

## 📋 Pull Request Checklist

Please review and check all the following:

- [x] I have added an overview of the changes
- [x] I have tested my changes locally
- [x] I have updated documentation (if applicable)

---

## 🚀 Versioning (Required for GitVersion)

- [ ] The **PR includes a commit** with one of the following GitVersion tags in the **message**:
  - `#major` – breaking change
  - `#minor` – new feature
  - `#patch` – bug fix or minor update  
  - _If omitted, the version will default to_ `patch`
