### PR TITLE
feat: A2 refinement

### DIFF
--- a/provisioning/finalization.yml
+++ b/provisioning/finalization.yml
@@ -121,19 +121,34 @@
       state: present
       src: dashboard-ingress.yaml
       namespace: kubernetes-dashboard
-#
-  # Step 23. Install Istio
+
+  - name: Determine architecture
+    ansible.builtin.shell: uname -m
+    register: arch_result
+
+  - name: Set Istio architecture
+    set_fact:
+      istio_arch: "{{ 'arm64' if arch_result.stdout == 'aarch64' else 'amd64' }}"
+
   - name: Download Istioctl
     ansible.builtin.get_url:
-      url: https://github.com/istio/istio/releases/download/1.25.2/istio-1.25.2-linux-amd64.tar.gz
-      dest: /home/vagrant/istio-1.25.2-linux-amd64.tar.gz
+      url: "https://github.com/istio/istio/releases/download/1.25.2/istio-1.25.2-linux-{{ istio_arch }}.tar.gz"
+      dest: "/home/vagrant/istio-1.25.2-linux-{{ istio_arch }}.tar.gz"
 
   - name: Unarchive Istioctl
     ansible.builtin.unarchive:
-      src: /home/vagrant/istio-1.25.2-linux-amd64.tar.gz
+      src: /home/vagrant/istio-1.25.2-linux-{{ istio_arch }}.tar.gz
       dest: /home/vagrant/
       remote_src: yes
 
+  - name: Add istioctl to global PATH using symlink
+    become: true
+    ansible.builtin.file:
+      src: /home/vagrant/istio-1.25.2/bin/istioctl
+      dest: /usr/local/bin/istioctl
+      state: link
+      force: yes
+      
   - name: Install Istioctl
     ansible.builtin.command: |
       istio-1.25.2/bin/istioctl install -y -f istioconfig.yml

--- a/scripts/vagrant_config_k8s.sh
+++ b/scripts/vagrant_config_k8s.sh
@@ -15,10 +15,8 @@ export KUBECONFIG="$CONFIG_FILE"
 echo "KUBECONFIG set to $KUBECONFIG"
 echo "Verifying access to the Kubernetes cluster..."
 
-
 kubectl get nodes
 
 echo "Checking if Flannel is working by checking the available pods"
 kubectl get pods -n kube-flannel
 
-kubectl get nodes


### PR DESCRIPTION
## Overview
- fixed OS-specific Istio binary issue to run on MacOS and on Linux.
- Fixed the installation of `istioctl` in the cluster.
- Refactored some README content to add clear instructions on provisioning the `finalization.yaml`

Note: Tested locally the entire Vagrant cluster and it works successfully. Also successfully tested that A5 is properly deployed in the Vagrant cluster (including rate limiting).

Closes #48 

## 📋 Pull Request Checklist

Please review and check all the following:

- [x] I have added an overview of the changes
- [x] I have tested my changes locally
- [x] I have updated documentation (if applicable)

---

## 🚀 Versioning (Required for GitVersion)

- [ ] The **PR includes a commit** with one of the following GitVersion tags in the **message**:
  - `#major` – breaking change
  - `#minor` – new feature
  - `#patch` – bug fix or minor update  
  - _If omitted, the version will default to_ `patch`
